### PR TITLE
Add missing return

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ module.exports = function(deps) {
   return function() {
     return function(next) {
       return function(action) {
-        next(typeof action === 'function' ? action(deps) : action);
+        return next(typeof action === 'function' ? action(deps) : action);
       };
     };
   };


### PR DESCRIPTION
Every middleware should return to allow further action processing.
redux-thunk returns too.
